### PR TITLE
Fix row separator false row breaks from sub-pixel rounding

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -494,7 +494,7 @@ window.fv3UpdateRowSeparators = (folderMap, folderId) => {
         let lastTop = wrappers[0].offsetTop;
         const rows = [[]];
         wrappers.forEach(w => {
-            if (w.offsetTop > lastTop) { rows.push([]); lastTop = w.offsetTop; }
+            if (w.offsetTop - lastTop > w.offsetHeight / 2) { rows.push([]); lastTop = w.offsetTop; }
             rows[rows.length - 1].push(w);
         });
         if (rows.length > 1) {


### PR DESCRIPTION
## Summary
- Row separator detection uses `offsetTop > lastTop` which triggers on 1px sub-pixel differences from `align-items: center` when containers have slightly different heights (e.g. update badge makes appname 18px vs 17px)
- Apply same `offsetHeight / 2` tolerance pattern used in clipPreview fix (v2026.04.08.1)
- Only detects genuine row wraps (~40px gap), not rounding artifacts (1-2px)

## Test plan
- [ ] Folder with expand mode + row separators + custom CSS theme that causes uneven container heights
- [ ] Verify separators still appear between actual rows with many containers
- [ ] Verify no phantom separators appear within a single row