### PR TITLE
Compute preview height offset from actual styles instead of hardcoded 10px

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -529,7 +529,10 @@ window.fv3SyncPreviewHeights = (cookieName) => {
         el.style.height = '';
         const cpuCell = el.closest('tr').querySelector('td.folder-advanced');
         if (isAdvanced && cpuCell && cpuCell.offsetHeight > 0) {
-            const targetHeight = cpuCell.offsetHeight - 10;
+            const elStyle = getComputedStyle(el);
+            const verticalGap = parseFloat(elStyle.marginTop) + parseFloat(elStyle.marginBottom)
+                + parseFloat(elStyle.borderTopWidth) + parseFloat(elStyle.borderBottomWidth);
+            const targetHeight = cpuCell.offsetHeight - (verticalGap || 10);
             const defaultHeight = el.offsetHeight;
             if (targetHeight > defaultHeight) {
                 el.style.height = targetHeight + 'px';


### PR DESCRIPTION
## Summary
- `fv3SyncPreviewHeights` used a hardcoded `- 10` offset when matching preview height to the advanced CPU cell height
- Custom CSS themes that change margins or borders on `.folder-preview` would cause incorrect height sync
- Now computes the actual vertical gap from `getComputedStyle` (margin + border), falling back to 10 if zero

## Test plan
- [ ] Toggle advanced view on Docker tab — preview heights should match CPU cell heights
- [ ] Apply a custom CSS theme that adds border to `.folder-preview` — heights should still align
- [ ] Verify no visual change with default CSS (fallback to 10 should match current behavior)