### PR TITLE
Fix dashboard fullwidth panel row detection with tolerance

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/dashboard.js
@@ -1636,7 +1636,7 @@ const fv3FullwidthReflowSync = (onlyType) => {
             const showcase = outer.find('.folder-showcase');
             const folderTile = outer.children('span.outer').first()[0];
             if (!folderTile) return;
-            const folderTop = Math.round(folderTile.getBoundingClientRect().top);
+            const folderTop = folderTile.getBoundingClientRect().top;
             let lastInRow = outer;
             const nextExpanded = idx < expandedOuters.length - 1 ? expandedOuters[idx + 1] : null;
             parentTd.children('.folder-showcase-outer, span.outer:not(:empty)').each(function() {
@@ -1649,7 +1649,7 @@ const fv3FullwidthReflowSync = (onlyType) => {
                     visualEl = this;
                 }
                 if (!visualEl || visualEl.offsetParent === null) return;
-                if (Math.round(visualEl.getBoundingClientRect().top) === folderTop) {
+                if (Math.abs(visualEl.getBoundingClientRect().top - folderTop) <= 2) {
                     lastInRow = $(this);
                 }
             });
@@ -1758,7 +1758,7 @@ const fv3FullwidthExpand = (id, type) => {
         const parentTd = $(`tbody#${tbody} > tr.updated > td`);
         const folderTile = outer.children('span.outer').first()[0];
         if (!folderTile) { showcase.css('display', ''); return; }
-        const folderTop = Math.round(folderTile.getBoundingClientRect().top);
+        const folderTop = folderTile.getBoundingClientRect().top;
 
         let lastInRow = outer;
         parentTd.children('.folder-showcase-outer, span.outer:not(:empty)').each(function() {
@@ -1771,7 +1771,7 @@ const fv3FullwidthExpand = (id, type) => {
             }
             if (!visualEl) return;
             if (visualEl.offsetParent === null) return;
-            if (Math.round(visualEl.getBoundingClientRect().top) === folderTop) {
+            if (Math.abs(visualEl.getBoundingClientRect().top - folderTop) <= 2) {
                 lastInRow = $(this);
             }
         });


### PR DESCRIPTION
## Summary
- Both `fv3RebuildFullwidthPanels` and `fv3FullwidthExpand` used `Math.round(getBoundingClientRect().top) === folderTop` to find the last tile in a row for fullwidth panel insertion
- Custom CSS that changes tile heights or adds transforms can cause 1-2px rounding differences, placing the fullwidth panel after the wrong tile
- Replace with `Math.abs(...) <= 2` tolerance — dashboard tiles are 80px+ tall so genuine row breaks are well above this threshold
- Also removes unnecessary `Math.round()` since we now compare with tolerance directly

## Test plan
- [ ] Dashboard with multiple expanded folders — fullwidth panels should appear after the correct row
- [ ] Resize browser to cause tiles to reflow between rows — panels should follow correctly
- [ ] Apply custom CSS theme with different tile padding/margins — panels should still align