### PR TITLE
Measure VM name column from .outer span instead of .inner text

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -136,10 +136,11 @@ const createFolders = async () => {
     applyVmZebra();
 
     let maxNameWidth = 0;
-    document.querySelectorAll('td.vm-name .inner, td.vm-name .folder-inner').forEach(el => {
+    document.querySelectorAll('td.vm-name .outer, td.vm-name .folder-outer').forEach(el => {
         if (el.scrollWidth > maxNameWidth) maxNameWidth = el.scrollWidth;
     });
-    const nameColWidth = Math.min(maxNameWidth + 80, 300);
+    const cellPadding = 16;
+    const nameColWidth = Math.min(maxNameWidth + cellPadding, 300);
     document.querySelectorAll('#vm_list th.th1').forEach(th => { th.style.width = nameColWidth + 'px'; });
 
     folderDebugMode  = false;


### PR DESCRIPTION
## Summary
- VM column width calculation measured only `.inner`/`.folder-inner` (text content) then added a hardcoded `+80px` for icon, padding, and dropdown
- Custom CSS themes that change `--fv3-folder-icon-size`, font-size, or padding would make the column too narrow or too wide
- Now measures `.outer`/`.folder-outer` which includes icon + text + dropdown naturally, and adds only cell padding (16px)

## Test plan
- [ ] VM tab with folders — column width should auto-size to fit longest name
- [ ] Apply custom CSS theme with larger icon size — column should still fit
- [ ] Verify column doesn't exceed 300px max with very long VM names
- [ ] Compare visual result with default CSS against current behavior (should be identical or very close)