### PR TITLE
Compute preview height offset from actual cell padding + preview gap

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -529,7 +529,12 @@ window.fv3SyncPreviewHeights = (cookieName) => {
         el.style.height = '';
         const cpuCell = el.closest('tr').querySelector('td.folder-advanced');
         if (isAdvanced && cpuCell && cpuCell.offsetHeight > 0) {
-            const targetHeight = cpuCell.offsetHeight - 10;
+            const cellStyle = getComputedStyle(cpuCell);
+            const cellPad = parseFloat(cellStyle.paddingTop) + parseFloat(cellStyle.paddingBottom);
+            const elStyle = getComputedStyle(el);
+            const elGap = parseFloat(elStyle.marginTop) + parseFloat(elStyle.marginBottom)
+                + parseFloat(elStyle.borderTopWidth) + parseFloat(elStyle.borderBottomWidth);
+            const targetHeight = cpuCell.offsetHeight - (cellPad + elGap || 10);
             const defaultHeight = el.offsetHeight;
             if (targetHeight > defaultHeight) {
                 el.style.height = targetHeight + 'px';


### PR DESCRIPTION
## Summary
- `fv3SyncPreviewHeights` used a hardcoded `- 10` offset when matching preview height to the advanced CPU cell height
- The 10px accounted for both the cell's padding AND the preview's margin/border, but custom CSS themes can change either
- v1 of this fix (PR #8) only measured preview margin+border, missing cell padding — previews became too tall with urblack theme
- Now computes: `cellPaddingTop + cellPaddingBottom + previewMarginTop + previewMarginBottom + previewBorderTop + previewBorderBottom`, falling back to 10 if zero

Replaces #8

## Test plan
- [ ] Toggle advanced view on Docker tab — preview heights should match CPU cell heights
- [ ] With urblack theme: verify no visual change from current behavior (computed gap should ≈ 10)
- [ ] With default CSS: verify no visual change (fallback to 10 matches current)