### PR TITLE
Compute VM name column offset from actual icon width and cell padding

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -136,10 +136,19 @@ const createFolders = async () => {
     applyVmZebra();
 
     let maxNameWidth = 0;
-    document.querySelectorAll('td.vm-name .inner, td.vm-name .folder-inner').forEach(el => {
-        if (el.scrollWidth > maxNameWidth) maxNameWidth = el.scrollWidth;
+    let nameExtra = 80;
+    document.querySelectorAll('td.vm-name').forEach(td => {
+        const inner = td.querySelector('.inner') || td.querySelector('.folder-inner');
+        if (!inner || !inner.scrollWidth) return;
+        if (inner.scrollWidth > maxNameWidth) {
+            maxNameWidth = inner.scrollWidth;
+            const outer = td.querySelector('.outer') || td.querySelector('.folder-outer');
+            const tdStyle = getComputedStyle(td);
+            const tdPad = parseFloat(tdStyle.paddingLeft) + parseFloat(tdStyle.paddingRight);
+            nameExtra = (outer ? outer.scrollWidth - inner.scrollWidth : 36) + tdPad;
+        }
     });
-    const nameColWidth = Math.min(maxNameWidth + 80, 300);
+    const nameColWidth = Math.min(maxNameWidth + nameExtra, 300);
     document.querySelectorAll('#vm_list th.th1').forEach(th => { th.style.width = nameColWidth + 'px'; });
 
     folderDebugMode  = false;


### PR DESCRIPTION
## Summary
- VM column width used `.inner` scrollWidth + hardcoded `+80px` for icon, padding, and dropdown
- v1 (PR #10) switched to measuring `.outer` + 16px, but cell padding varies (26px for folder rows vs 16px for VM rows) making the column 20px too narrow
- Now computes the actual offset: `(outer.scrollWidth - inner.scrollWidth)` for icon+dropdown width, plus `getComputedStyle(td).paddingLeft + paddingRight` for cell padding
- Falls back to 80px if elements aren't found

Replaces #10

## Test plan
- [ ] VM tab with folders — column width should match current behavior exactly
- [ ] VM tab with urblack theme — verify no truncation
- [ ] VM tab with default CSS — verify identical to current behavior
- [ ] VM tab with very long VM names — verify 300px max still applies