### PR TITLE
Compute VM name column offset from actual icon width and cell padding

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/vm.js
@@ -136,10 +136,19 @@ const createFolders = async () => {
     applyVmZebra();
 
     let maxNameWidth = 0;
-    document.querySelectorAll('td.vm-name .inner, td.vm-name .folder-inner').forEach(el => {
-        if (el.scrollWidth > maxNameWidth) maxNameWidth = el.scrollWidth;
+    let nameExtra = 80;
+    document.querySelectorAll('td.vm-name').forEach(td => {
+        const inner = td.querySelector('.inner') || td.querySelector('.folder-inner');
+        if (!inner || !inner.scrollWidth) return;
+        if (inner.scrollWidth > maxNameWidth) {
+            maxNameWidth = inner.scrollWidth;
+            const outer = td.querySelector('.outer') || td.querySelector('.folder-outer');
+            const tdStyle = getComputedStyle(td);
+            const tdPad = parseFloat(tdStyle.paddingLeft) + parseFloat(tdStyle.paddingRight);
+            nameExtra = (outer ? outer.scrollWidth - inner.scrollWidth : 36) + tdPad + 10;
+        }
     });
-    const nameColWidth = Math.min(maxNameWidth + 80, 300);
+    const nameColWidth = Math.min(maxNameWidth + nameExtra, 300);
     document.querySelectorAll('#vm_list th.th1').forEach(th => { th.style.width = nameColWidth + 'px'; });
 
     folderDebugMode  = false;


### PR DESCRIPTION
## Summary
- VM column width used `.inner` scrollWidth + hardcoded `+80px` for icon, padding, and dropdown
- v1 (#10) measured `.outer + 16` — too narrow (missed cell padding). v2 (#12) measured `.outer - .inner + tdPad` — still 8-10px too narrow (missed the original buffer)
- v3 adds 10px buffer: `(outer - inner) + tdPad + 10`, producing identical results to hardcoded 80 on default CSS (~82px computed) and adapting correctly when custom CSS changes icon/padding sizes
- Falls back to 80 if elements aren't found

Replaces #10, #12

## Test plan
- [ ] VM tab default CSS — column width should be identical to current (`+80` → computed `~82`)
- [ ] VM tab urblack theme — column width should be identical to current (`+80` → computed `~80`)
- [ ] VM tab with very long VM names — verify 300px max still applies