### PR TITLE
Compute preview height offset from actual styles with 10px minimum

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -529,7 +529,12 @@ window.fv3SyncPreviewHeights = (cookieName) => {
         el.style.height = '';
         const cpuCell = el.closest('tr').querySelector('td.folder-advanced');
         if (isAdvanced && cpuCell && cpuCell.offsetHeight > 0) {
-            const targetHeight = cpuCell.offsetHeight - 10;
+            const cellStyle = getComputedStyle(cpuCell);
+            const cellPad = parseFloat(cellStyle.paddingTop) + parseFloat(cellStyle.paddingBottom);
+            const elStyle = getComputedStyle(el);
+            const elGap = parseFloat(elStyle.marginTop) + parseFloat(elStyle.marginBottom)
+                + parseFloat(elStyle.borderTopWidth) + parseFloat(elStyle.borderBottomWidth);
+            const targetHeight = cpuCell.offsetHeight - Math.max(cellPad + elGap, 10);
             const defaultHeight = el.offsetHeight;
             if (targetHeight > defaultHeight) {
                 el.style.height = targetHeight + 'px';


### PR DESCRIPTION
## Summary
- `fv3SyncPreviewHeights` used a hardcoded `- 10` offset when matching preview height to the CPU cell
- v1 (#8) only measured preview margin/border — too small. v2 (#11) added cell padding but used `|| 10` fallback — still produced smaller gaps than the original 10px on both default CSS (5.8px) and urblack (7.8px)
- v3 uses `Math.max(cellPad + elGap, 10)` — preserves current behavior as a minimum floor, but allows the gap to grow if custom CSS adds significant borders or margins
- No visible change on default or urblack CSS; only themes that push padding+borders above 10px will see a difference

Replaces #8, #11

## Test plan
- [ ] Docker tab advanced view, default CSS — preview heights identical to current
- [ ] Docker tab advanced view, urblack theme — preview heights identical to current
- [ ] Docker tab advanced view with custom CSS adding 5px border to `.folder-preview` — gap should grow to accommodate