### PR TITLE
fix(preview): size Docker folder columns by percentage so fixed layout survives fractional DPR

### DIFF
--- a/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
+++ b/src/folder.view3/usr/local/emhttp/plugins/folder.view3/scripts/shared.js
@@ -1839,10 +1839,19 @@ window.fv3ApplyCachedWidths = () => {
     const headers = Array.from(tbl.querySelectorAll('thead > tr > th'));
     if (headers.length !== snap.headerCount) return;
     const widths = fv3AnyNonFolderRowVisible() ? snap.expanded : snap.collapsed;
+    // Apply the cached column widths as PERCENTAGES of the table width rather than pixels.
+    // distributeSlack() already forces the snapshot to sum to the table's target width, so each
+    // column's share is simply widths[i] / total. Under table-layout:fixed, percentage column
+    // widths are resolved relative to the table box, so there is no per-column pixel value to
+    // round and accumulate — the rounding drift that collapsed the colspan preview cell at
+    // FRACTIONAL devicePixelRatio (e.g. Windows display scaling 125%) does not arise. This mirrors
+    // how Unraid's own fixed-layout tables (disk_status / array_status / share_status) size their
+    // columns: table-layout:fixed paired with percentage widths, never pinned pixels.
+    const total = widths.reduce((a, b) => a + b, 0);
     headers.forEach((th, i) => {
         if (snap.displayHidden[i]) return;
         th.style.boxSizing = 'border-box';
-        th.style.width = widths[i] + 'px';
+        th.style.width = total > 0 ? (widths[i] / total * 100) + '%' : '';
         if (widths[i] === 0) {
             th.style.padding = '0';
             th.style.fontSize = '0';
@@ -1851,14 +1860,10 @@ window.fv3ApplyCachedWidths = () => {
             th.style.fontSize = '';
         }
     });
-    // table-layout:fixed gives stable columns, but at FRACTIONAL devicePixelRatio (e.g. Windows
-    // display scaling 125%) the browser's fixed-layout colspan distribution breaks and collapses
-    // the folder preview cell (a colspan cell), pushing it right / clipping it. FolderView2 never
-    // had this because it used the browser's default (auto) layout. So only lock to fixed at
-    // INTEGER DPR; at fractional DPR fall back to auto layout (the th width hints above keep the
-    // columns aligned), which sizes the colspan cell correctly. Setting widths on the body cells
-    // does NOT help — under table-layout:fixed the column widths come from the <th>, not the cells.
-    tbl.style.tableLayout = Number.isInteger(window.devicePixelRatio) ? 'fixed' : 'auto';
+    // Percentage widths keep the fixed-layout column distribution stable at every devicePixelRatio,
+    // so we can lock to table-layout:fixed unconditionally — no auto fallback (and its dependence on
+    // <th> width hints) is needed.
+    tbl.style.tableLayout = 'fixed';
     if (window.fv3SchedulePillSize) window.fv3SchedulePillSize();
 };
 


### PR DESCRIPTION
## Summary

An **alternative** to the `2026.06.15.1` auto-layout fallback for the fractional-DPR preview-collapse bug (#175). Instead of dropping to `table-layout: auto` when `devicePixelRatio` is non-integer, this keeps `table-layout: fixed` **everywhere** and expresses the cached column widths as **percentages** of the table width instead of pixels.

Single-function change in `fv3ApplyCachedWidths` (`scripts/shared.js`).

## Why percentages

`distributeSlack()` already forces the width snapshot to sum to the table's target width, so the conversion is exact and needs no re-measurement:

```js
const total = widths.reduce((a, b) => a + b, 0);
th.style.width = total > 0 ? (widths[i] / total * 100) + '%' : '';
...
tbl.style.tableLayout = 'fixed';   // unconditionally
```

Under `table-layout: fixed`, percentage column widths are resolved relative to the table box, so there is no per-column **pixel** value for the browser to round. The rounding drift that collapsed the `colspan` preview cell at fractional DPR (Windows display scaling 125%, non-100% browser zoom) therefore doesn't arise.

## Prior art (the reason for this approach)

This mirrors how Unraid's own fixed-layout tables size their columns. From `emhttp/plugins/dynamix/styles/default-base.css`:

```css
table.disk_status  { table-layout: fixed; }
table.disk_status tr > td:nth-child(1) { width: 13%; }   /* % widths, never pixels */
table.array_status { table-layout: fixed; }              /* td:nth-child(1){width:33%} */
table.share_status { table-layout: fixed; }              /* td:nth-child(1){width:15%} */
```

Unraid only ever pairs `table-layout: fixed` with **percentage** columns; the native Docker table (`tablesorter shift`) stays auto-layout and, when it pins widths at all, pins both `<th>` and `<td>` in pixels via JS. It never combines fixed layout with pinned-pixel columns — which is exactly the combination that produced this bug.

## Behaviour

- **Integer DPR** — columns sum to 100% of the same target width, so layout is effectively unchanged from the pixel version (±1px rounding).
- **Fractional DPR** — stays `fixed` (no auto fallback); columns scale proportionally with the table box.
- Hidden columns (`displayHidden`) and the collapsed Uptime column (`width 0` → `0%`, padding/font zeroed) are handled exactly as before.

## ⚠️ Review notes — not merge-ready as-is

- **Not yet verified at fractional DPR.** Maintainer machines are integer-DPR, so the core claim (percentages fix the colspan collapse under `fixed`) needs a capture from an affected user (or a throttled/zoomed repro) before merge. The shipped `2026.06.15.1` auto-layout fallback remains the **proven** fix; this is the percentage alternative for evaluation, not a replacement yet.
- **No `.plg` version bump or `CHANGELOG-fixes.md` entry** — deliberately left out (the `pluginURL` branch-match guard and build-number choice are better set at merge time).
- Open question for you: if it verifies, do you want this to **replace** the auto fallback, or keep auto as a belt-and-suspenders for any browser that mishandles `%` + colspan under `fixed`?

Opened as a **draft** for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_016UJkLkYG1Ao3Rd2TpAQbJS)_